### PR TITLE
Add iron and gold ores to #c:iron_ores and #c:gold_ores for tech mods compat

### DIFF
--- a/src/main/resources/data/c/tags/items/gold_ores.json
+++ b/src/main/resources/data/c/tags/items/gold_ores.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#unearthed:gold_ores"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/iron_ores.json
+++ b/src/main/resources/data/c/tags/items/iron_ores.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#unearthed:iron_ores"
+  ]
+}


### PR DESCRIPTION
This pull request creates tag files which add the contents of `#unearthed:iron_ores` to `#c:iron_ores`, and the contents of `#unearthed:gold_ores` to `#c:gold_ores`, so that tech mods' grinders can grind the ore variants. This fixes #52.~